### PR TITLE
CORE-412: Use -c rather than -z to accommodate purge of vault support in porklock

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func (a *App) downloadCommand() []string {
 		"--user", a.User,
 		"--source-list", a.InputPathList,
 		"--destination", a.DownloadDestination,
-		"-z", a.ConfigPath,
+		"-c", a.ConfigPath,
 	}
 	for _, fm := range a.FileMetadata {
 		retval = append(retval, "-m", fm)
@@ -323,7 +323,7 @@ func (a *App) uploadCommand() []string {
 		"--source", a.DownloadDestination,
 		"--destination", a.UploadDestination,
 		"--exclude", a.ExcludesPath,
-		"-z", a.ConfigPath,
+		"-c", a.ConfigPath,
 	}
 	for _, fm := range a.FileMetadata {
 		retval = append(retval, "-m", fm)


### PR DESCRIPTION
This is tiny and I'll just merge it after cyverse-de/porklock#5 gets merged. But I figured putting up a PR was still nicer than not.